### PR TITLE
Ensured that every new cookbook has at least one menu plan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,11 @@ group :development, :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", "~> 2.13"
   gem "selenium-webdriver"
+
+  gem "factory_girl_rails"
+  gem "shoulda-context"
+  gem "minitest-reporters"
+  gem "minitest-reporters-turn_reporter"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
+    ansi (1.5.0)
     arel (8.0.0)
     aws-sdk (2.10.24)
       aws-sdk-resources (= 2.10.24)
@@ -97,6 +98,11 @@ GEM
       warden (~> 1.2.3)
     erubi (1.6.1)
     execjs (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
@@ -126,6 +132,13 @@ GEM
     mini_magick (4.8.0)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
+    minitest-reporters (1.1.14)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    minitest-reporters-turn_reporter (0.1.2)
+      minitest-reporters
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -201,6 +214,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    ruby-progressbar (1.8.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.5.1)
@@ -217,6 +231,7 @@ GEM
     selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    shoulda-context (1.2.2)
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
@@ -259,10 +274,13 @@ DEPENDENCIES
   carrierwave-aws
   coffee-rails (~> 4.2)
   devise
+  factory_girl_rails
   hangry!
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
+  minitest-reporters
+  minitest-reporters-turn_reporter
   omniauth-google-oauth2
   pg
   pg_search
@@ -273,6 +291,7 @@ DEPENDENCIES
   redcarpet
   sass-rails (~> 5.0)
   selenium-webdriver
+  shoulda-context
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -2,5 +2,16 @@ class Cookbook < ApplicationRecord
 
   has_many :users
   has_many :recipes
+  has_many :menu_plans
+  belongs_to :current_menu_plan, class_name: "MenuPlan", required: false
+
+  after_create :create_first_menu_plan!
+
+private
+
+  def create_first_menu_plan!
+    self.current_menu_plan = menu_plans.create!(name: "My First Menu Plan")
+    update_column :current_menu_plan_id, current_menu_plan.id
+  end
 
 end

--- a/app/models/menu_plan.rb
+++ b/app/models/menu_plan.rb
@@ -1,0 +1,5 @@
+class MenuPlan < ApplicationRecord
+
+  belongs_to :cookbook
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,9 @@ class User < ApplicationRecord
 
   devise :trackable, :omniauthable, omniauth_providers: [:google_oauth2]
 
-  before_create :create_cookbook_for_user
+  before_validation :create_cookbook_for_user, on: :create
+
+  delegate :current_menu_plan, to: :cookbook
 
   def self.from_omniauth(access_token)
     info = access_token.info

--- a/db/migrate/20170812171824_create_menu_plans.rb
+++ b/db/migrate/20170812171824_create_menu_plans.rb
@@ -1,0 +1,27 @@
+class CreateMenuPlans < ActiveRecord::Migration[5.1]
+  def up
+    create_table :menu_plans do |t|
+      t.belongs_to :cookbook, null: false, foreign_key: { to_table: :cookbooks, on_delete: :cascade }, index: true
+      t.string :name, null: false
+    end
+
+    add_column :cookbooks, :current_menu_plan_id, :integer
+
+    Cookbook.find_each do |cookbook|
+      cookbook.send :create_first_menu_plan!
+    end
+
+    # TODO: make cookbooks.current_menu_plan_id NOT NULL — but defer the constraint
+    #       so that it is only evaluated at the end of a transaction so that
+    #       we can get the cookbook into the database before we create the first
+    #       menu plan that belongs to it. This is probably a Postgres-only feature
+    #       and we should switch from schema.rb to structure.sql
+
+    add_foreign_key :cookbooks, :menu_plans, column: :current_menu_plan_id
+  end
+
+  def down
+    remove_column :cookbooks, :current_menu_plan_id
+    drop_table :menu_plans
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,73 +10,79 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170731024902) do
+ActiveRecord::Schema.define(version: 20170812171824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
-  create_table "cookbooks", force: true do |t|
-    t.string   "name",       null: false
+  create_table "cookbooks", id: :serial, force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "current_menu_plan_id"
+  end
+
+  create_table "menu_plans", force: :cascade do |t|
+    t.bigint "cookbook_id", null: false
+    t.string "name", null: false
+    t.index ["cookbook_id"], name: "index_menu_plans_on_cookbook_id"
+  end
+
+  create_table "photos", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.string "filename", limit: 255, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
-  create_table "photos", id: :uuid, default: "uuid_generate_v4()", force: true do |t|
-    t.string   "filename",   null: false
+  create_table "ratings", id: :serial, force: :cascade do |t|
+    t.integer "recipe_id"
+    t.integer "user_id"
+    t.string "name", limit: 255, null: false
+    t.integer "value", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.index ["recipe_id", "user_id"], name: "index_ratings_on_recipe_id_and_user_id"
   end
 
-  create_table "ratings", force: true do |t|
-    t.integer  "recipe_id"
-    t.integer  "user_id"
-    t.string   "name",       null: false
-    t.integer  "value",      null: false
+  create_table "recipes", id: :serial, force: :cascade do |t|
+    t.string "name", limit: 255, null: false
+    t.text "ingredients", null: false
+    t.text "instructions", null: false
+    t.string "tags", limit: 255, default: [], array: true
+    t.integer "effort"
+    t.integer "cost"
+    t.integer "healthiness"
     t.datetime "created_at"
     t.datetime "updated_at"
-  end
-
-  add_index "ratings", ["recipe_id", "user_id"], name: "index_ratings_on_recipe_id_and_user_id", using: :btree
-
-  create_table "recipes", force: true do |t|
-    t.string   "name",                       null: false
-    t.text     "ingredients",                null: false
-    t.text     "instructions",               null: false
-    t.string   "tags",          default: [],              array: true
-    t.integer  "effort"
-    t.integer  "cost"
-    t.integer  "healthiness"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "created_by_id",              null: false
+    t.integer "created_by_id", null: false
     t.tsvector "search_vector"
-    t.integer  "cookbook_id",                null: false
-    t.string   "source"
-    t.string   "servings",      default: "", null: false
-    t.uuid     "photo_id"
+    t.integer "cookbook_id", null: false
+    t.string "source", limit: 255
+    t.string "servings", limit: 255, default: "", null: false
+    t.uuid "photo_id"
+    t.index ["cookbook_id"], name: "index_recipes_on_cookbook_id"
+    t.index ["search_vector"], name: "index_recipes_on_search_vector", using: :gin
+    t.index ["tags"], name: "index_recipes_on_tags", using: :gin
   end
 
-  add_index "recipes", ["cookbook_id"], name: "index_recipes_on_cookbook_id", using: :btree
-  add_index "recipes", ["search_vector"], name: "index_recipes_on_search_vector", using: :gin
-  add_index "recipes", ["tags"], name: "index_recipes_on_tags", using: :gin
-
-  create_table "users", force: true do |t|
-    t.string   "email",              default: "", null: false
-    t.integer  "sign_in_count",      default: 0,  null: false
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", limit: 255, default: "", null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string "current_sign_in_ip", limit: 255
+    t.string "last_sign_in_ip", limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "first_name",                      null: false
-    t.string   "image_url"
-    t.string   "last_name"
-    t.integer  "cookbook_id",                     null: false
+    t.string "first_name", limit: 255, null: false
+    t.string "image_url", limit: 255
+    t.string "last_name", limit: 255
+    t.integer "cookbook_id", null: false
+    t.index ["cookbook_id"], name: "index_users_on_cookbook_id"
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_index "users", ["cookbook_id"], name: "index_users_on_cookbook_id", using: :btree
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-
+  add_foreign_key "cookbooks", "menu_plans", column: "current_menu_plan_id"
+  add_foreign_key "menu_plans", "cookbooks", on_delete: :cascade
 end

--- a/test/factories/cookbook_factory.rb
+++ b/test/factories/cookbook_factory.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :cookbook do
+    name "Factory Cookbook"
+  end
+end

--- a/test/factories/user_factory.rb
+++ b/test/factories/user_factory.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :user do
+    first_name "John"
+    last_name  "Doe"
+    email "john.doe@factory.com"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,12 @@
-require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
+require File.expand_path("../../config/environment", __FILE__)
+require "rails/test_help"
+
+require "minitest/reporters/turn_reporter"
+MiniTest::Reporters.use! Minitest::Reporters::TurnReporter.new
 
 class ActiveSupport::TestCase
+  include FactoryGirl::Syntax::Methods
+
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 

--- a/test/unit/models/cookbook_test.rb
+++ b/test/unit/models/cookbook_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class CookbookTest < ActiveSupport::TestCase
+
+  context "Creating a cookbook" do
+    should "also create a current menu plan for the cookbook" do
+      cookbook = create(:cookbook)
+      assert cookbook.current_menu_plan, "Expected the new cookbook to have a current menu plan"
+    end
+  end
+
+end

--- a/test/unit/models/user_test.rb
+++ b/test/unit/models/user_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+
+  context "Creating a user" do
+    should "also create a cookbook for the user" do
+      user = create(:user)
+      assert user.cookbook, "Expected the new user to have a cookbook"
+    end
+  end
+
+end


### PR DESCRIPTION
### Details

 - Menu Plans belong to cookbooks (should these be called "families"?) not to users so that spouses can collaborate on them
 - When a new user signs up, they'll implicitly have a cookbook (to which other users can be added) and that cookbook will have a first menu plan (so they can start adding recipes to it)
