### PR TITLE
Only display source hostname

### DIFF
--- a/app/helpers/recipe_helper.rb
+++ b/app/helpers/recipe_helper.rb
@@ -12,7 +12,7 @@ module RecipeHelper
 
   def format_source(source)
     if source =~ /:\/\//
-      link_to source, source
+      link_to URI(source).host, source
     else
       h source
     end


### PR DESCRIPTION
I agree with Rachel that it's better to quickly see where the recipe comes from.

How do you feel about truncating it?

**Current**:
![screenshot 2017-08-13 07 27 02](https://user-images.githubusercontent.com/3615754/29253972-8cfd7abe-8050-11e7-847d-a44c5d356403.png)


**With this change**:

![screenshot 2017-08-13 17 53 26](https://user-images.githubusercontent.com/3615754/29253976-916b92ca-8050-11e7-92a8-2aad323474df.png)
