### PR TITLE
Handle bad URIs when parsing recipe sources

### DIFF
--- a/app/helpers/recipe_helper.rb
+++ b/app/helpers/recipe_helper.rb
@@ -35,9 +35,9 @@ module RecipeHelper
   end
 
   def format_source(source)
-    if source =~ /:\/\//
+    begin
       link_to URI(source).host, source
-    else
+    rescue URI::InvalidURIError
       h source
     end
   end

--- a/test/unit/helpers/recipe_helper_test.rb
+++ b/test/unit/helpers/recipe_helper_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class RecipeHelperTest < ActionView::TestCase
+  include ERB::Util
+
+  context "#format_source" do
+    context "when the source is a valid URI, it" do
+      should 'create an anchor element' do
+        assert_dom_equal %{<a href="http://pinchofyum.com/thai-yellow-curry-with-beef-and-potatoes">pinchofyum.com</a>}, format_source("http://pinchofyum.com/thai-yellow-curry-with-beef-and-potatoes")
+      end
+    end
+
+    context "when the source is an invalid URI, it" do
+      should "return the escaped string" do
+        assert_dom_equal %{This is not valid &amp;&amp; http://cool.com}, format_source("This is not valid && http://cool.com")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem
The site throws a 500 when it cannot parse a Recipe's source.

## Solution
Rescue from the error!