### PR TITLE
fix: Normalize tag names before creating tags on-demand

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,15 +16,11 @@ class Tag < ApplicationRecord
   end
 
   def self.find_or_create_for(*names)
-    names = names.flatten
-    tags = named(names).to_a
-    missing_names = names - tags.map(&:name)
+    normal_names = names.flatten.map(&method(:normalize)).uniq
+    tags = where(name: normal_names).to_a
+    missing_names = normal_names - tags.map(&:name)
     tags.concat create(missing_names.map { |name| { name: name } }) if missing_names.any?
     tags
-  end
-
-  def self.named(*names)
-    where(name: names.flatten.map(&method(:normalize)).uniq)
   end
 
   def self.normalize(value)

--- a/test/factories/tag_factory.rb
+++ b/test/factories/tag_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    association :cookbook
+  end
+end

--- a/test/unit/models/recipe_test.rb
+++ b/test/unit/models/recipe_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
 class RecipeTest < ActiveSupport::TestCase
-
   context "Assigning #copy_of" do
     setup do
       @recipe = create(:recipe, source: "SOURCE", photo_id: 9)
@@ -33,6 +32,34 @@ class RecipeTest < ActiveSupport::TestCase
 
     should "return Ingreedy parsed ingredients" do
       assert_kind_of Ingreedy::Parser::Result, @recipe.parsed_ingredients.first
+    end
+  end
+
+  context "#tags" do
+    should "create a new Tag" do
+      assert_difference -> { Tag.count }, 1 do
+        create(:recipe, tags: %w{gluten-free})
+      end
+    end
+
+    should "associate an existing Tag" do
+      cookbook = create(:cookbook)
+      tag = create(:tag, cookbook: cookbook, name: "gluten-free")
+
+      assert_no_difference -> { Tag.count } do
+        recipe = create(:recipe, cookbook: cookbook, tags: [tag.name])
+        assert_equal [tag], recipe.tags.to_a
+      end
+    end
+
+    should "be case-insensitive" do
+      cookbook = create(:cookbook)
+      tag = create(:tag, cookbook: cookbook, name: "gluten-free")
+
+      assert_no_difference -> { Tag.count } do
+        recipe = create(:recipe, cookbook: cookbook, tags: %w{Gluten-Free})
+        assert_equal [tag], recipe.tags.to_a
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves an issue where if the tag `"tag"` existed and you tried to tag a new recipe `"Tag"`, it would fail to find the existing tag and attempt to create a new tag named `"tag"` (the normalized form of `"Tag"`)